### PR TITLE
Remove Data.Kind import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        cabal: ["3.2.0.0", "3.4.0.0"]
+        cabal: ["3.4.0.0"]
         ghc:   ["8.8", "8.10"]
 
     name: GHC ${{ matrix.ghc }}, Cabal ${{ matrix.cabal }}

--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,7 @@ packages:
   clash-systolic.cabal
 
 package clash-prelude
+  documentation: True
   flags: -large-tuples
 
 package clash-systolic

--- a/src/Clash/Systolic/Network/Pipeline.hs
+++ b/src/Clash/Systolic/Network/Pipeline.hs
@@ -13,7 +13,6 @@ module Clash.Systolic.Network.Pipeline
   ) where
 
 import Clash.Prelude
-import Data.Kind
 
 import Clash.Systolic.Cell
 import Clash.Systolic.Network

--- a/src/Clash/Systolic/Network/Rectangle.hs
+++ b/src/Clash/Systolic/Network/Rectangle.hs
@@ -15,7 +15,6 @@ module Clash.Systolic.Network.Rectangle
 
 import Clash.Prelude
 import Data.Bifunctor
-import Data.Kind
 
 import Clash.Systolic.Cell
 import Clash.Systolic.Network


### PR DESCRIPTION
Since Clash.Prelude now re-exports Data.Kind, the import is not
needed here.